### PR TITLE
console script definition for pipx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,9 @@ setup(
     ],
     python_requires=">=3.11",
     install_requires=required_packages,
+    entry_points={
+    'console_scripts': [
+        'smartcut=smartcut.__main__:main',
+    ],
+},
 )


### PR DESCRIPTION
This addition allows binary to be properly installed with `pipx` and expose `smartcut` command globally without explicitly activating the virtual environment. With it you can just run `pipx install git+https://github.com/skeskinen/smartcut --include-deps` and after that use `smartcut` inside other scripts. Without this additiion pipx will install its venv for application but will not link it to any executable.